### PR TITLE
Fix conversion of SVG files

### DIFF
--- a/lib/Foswiki/Plugins/ImagePlugin/Core.pm
+++ b/lib/Foswiki/Plugins/ImagePlugin/Core.pm
@@ -1066,7 +1066,7 @@ sub getImageFile {
   my $digest = Digest::MD5::md5_hex($size, $zoom, $crop, $rotate, $frame, $fileSize);
 
   # force conversion of some non-webby image formats
-  $imgFile =~ s/\.(tiff?|xcf|psd)$/\.png/g;
+  $imgFile =~ s/\.(svgz?|tiff?|xcf|psd)$/\.png/g;
 
   # switch manually specified output format
   if ($output && $imgFile =~ /^(.+)\.([^\.]+)$/) {


### PR DESCRIPTION
ImageMagick or GraphicsMagick don't really support outputting SVG files.
Depending on the version, they either exit with an error or create an
SVG file containing a base64-encoded PNG. Consequently, it's better to
create a PNG file directly instead.

[Here's an example of such a PNG-in-an-SVG-file on foswiki.org](http://foswiki.org/pub/Community/BrandLogoTalk/igp_83330e418740be586efde6ce0d674ff0_foswiki-logo-final.svg). Coincidentally, the resulting SVG file doesn't even work in my browser. 
